### PR TITLE
Implement TLS 1.2 for SCS remote requests, to improve cipher security

### DIFF
--- a/ContentMigrator/ContentMigrationHandler.cs
+++ b/ContentMigrator/ContentMigrationHandler.cs
@@ -43,7 +43,7 @@ namespace ScsContentMigrator
 		public override string ResourcesPath { get; set; } = "ScsContentMigrator.Resources";
 		public override string Icon => "/scs/cm.png";
 		public override string Name => "Content Migrator";
-		public override string CssStyle => "width:800px";
+		public override string CssStyle => "width:100%;min-width:800px;";
 
 		public ContentMigrationHandler(string roles, string isAdmin, string users, string remotePullingThreads, string databaseWriterThreads, string authenticationSecret) : base(roles, isAdmin, users)
 		{

--- a/ContentMigrator/Data/CompareContentTreeNode.cs
+++ b/ContentMigrator/Data/CompareContentTreeNode.cs
@@ -48,7 +48,7 @@ namespace ScsContentMigrator.Data
 
 		public IItemData ItemData()
 		{
-			return GetResources.DeserializeYaml(Data, Id);
+			return RemoteContentService.DeserializeYaml(Data, Id);
 		}
 
 		private bool AreFieldsEqual(Field local, IItemFieldValue remote)
@@ -71,7 +71,7 @@ namespace ScsContentMigrator.Data
 				{
 					if (Data != null)
 					{
-						var itemData = GetResources.DeserializeYaml(Data, itemId);
+						var itemData = RemoteContentService.DeserializeYaml(Data, itemId);
 						var localItem = Factory.GetDatabase(database, true).DataManager.DataEngine.GetItem(new ID(itemId), LanguageManager.DefaultLanguage, Sitecore.Data.Version.Latest);
 
 						Status = new List<Tuple<string, string>>();

--- a/ContentMigrator/OperationStatus.cs
+++ b/ContentMigrator/OperationStatus.cs
@@ -110,7 +110,7 @@ namespace ScsContentMigrator
 			{
 				foreach (string id in _args.ids)
 				{
-					IItemData idata = GetResources.GetRemoteItemData(_args, id);
+					IItemData idata = RemoteContentService.GetRemoteItemData(_args, id);
 
 					Item parent = _db.GetItem(new ID(idata.ParentId));
 					IItemData tmpData = idata;
@@ -141,7 +141,7 @@ namespace ScsContentMigrator
 						{
 							parent = _db.GetItem(new ID(tmpData.ParentId));
 							path.Push(tmpData);
-							tmpData = GetResources.GetRemoteItemData(_args, tmpData.ParentId.ToString());
+							tmpData = RemoteContentService.GetRemoteItemData(_args, tmpData.ParentId.ToString());
 						}
 
 						while (path.Any())
@@ -332,7 +332,7 @@ namespace ScsContentMigrator
 			}
 			else
 			{
-				IItemData idata = GetResources.GetRemoteItemData(_args, item);
+				IItemData idata = RemoteContentService.GetRemoteItemData(_args, item);
 				_installerQueue.Enqueue(idata);
 				if (_args.children)
 				{
@@ -343,7 +343,7 @@ namespace ScsContentMigrator
 
 		private void QueueChildren(object item)
 		{
-			var list = GetResources.GetRemoteItemChildren(_args, item.ToString()).ToList();
+			var list = RemoteContentService.GetRemoteItemChildren(_args, item.ToString()).ToList();
 			foreach (string id in list)
 			{
 				_tp.Queue(GetNextItem, id);

--- a/ContentMigrator/ScsContentMigrator.csproj
+++ b/ContentMigrator/ScsContentMigrator.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\inetpub\wwwroot\Debut\Source\Debut.Web\bin\</OutputPath>
+    <OutputPath>..\..\..\bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/ContentMigrator/ScsContentMigrator.csproj
+++ b/ContentMigrator/ScsContentMigrator.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
+    <OutputPath>..\..\..\inetpub\wwwroot\Debut\Source\Debut.Web\bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/ContentMigrator/ScsContentMigrator.csproj
+++ b/ContentMigrator/ScsContentMigrator.csproj
@@ -112,7 +112,7 @@
     <Compile Include="ContentMigrationHandler.cs" />
     <Compile Include="Data\CompareContentTreeNode.cs" />
     <Compile Include="ErrorItemData.cs" />
-    <Compile Include="GetResources.cs" />
+    <Compile Include="RemoteContentService.cs" />
     <Compile Include="ItemExtensions.cs" />
     <Compile Include="OperationStatus.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/ScsAuditLog/AuditLogHandler.cs
+++ b/ScsAuditLog/AuditLogHandler.cs
@@ -29,7 +29,7 @@ namespace ScsAuditLog
 		public override string ResourcesPath { get; set; } = "ScsAuditLog.Resources";
 		public override string Icon { get; } = "/scs/alportfoliofolder.png";
 		public override string Name { get; } = "Audit Log";
-		public override string CssStyle { get; } = "width:1000px";
+		public override string CssStyle { get; } = "width:100%;min-width:900px";
 		private readonly List<string> _luceneSpecialChars = new List<string>() { "+", "-", "&&", "||", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "*", "?", ":", "\\" };
 
 		public AuditLogHandler(string keepBackups, string keepRecords, string roles, string isAdmin, string users) : base(roles, isAdmin, users)

--- a/ScsAuditLog/ScsAuditLog.csproj
+++ b/ScsAuditLog/ScsAuditLog.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\inetpub\wwwroot\Debut\Source\Debut.Web\bin\</OutputPath>
+    <OutputPath>..\..\..\bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/ScsAuditLog/ScsAuditLog.csproj
+++ b/ScsAuditLog/ScsAuditLog.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
+    <OutputPath>..\..\..\inetpub\wwwroot\Debut\Source\Debut.Web\bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/ScsEditingContext/EditingContextHandler.cs
+++ b/ScsEditingContext/EditingContextHandler.cs
@@ -27,7 +27,7 @@ namespace ScsEditingContext
 		public override string ResourcesPath { get; set; } = "ScsEditingContext.Resources";
 		public override string Icon => "/scs/ec.png";
 		public override string Name => "Editing Context";
-		public override string CssStyle => "width:600px";
+		public override string CssStyle => "width:100%;min-width:600px";
 
 		public static Database Core = Factory.GetDatabase("core");
 		public static Database Master = Factory.GetDatabase("master");

--- a/ScsEditingContext/ScsEditingContext.csproj
+++ b/ScsEditingContext/ScsEditingContext.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\inetpub\wwwroot\Debut\Source\Debut.Web\bin\</OutputPath>
+    <OutputPath>..\..\..\bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/ScsEditingContext/ScsEditingContext.csproj
+++ b/ScsEditingContext/ScsEditingContext.csproj
@@ -19,7 +19,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
+    <OutputPath>..\..\..\inetpub\wwwroot\Debut\Source\Debut.Web\bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -11,4 +11,4 @@ using System.Runtime.InteropServices;
 [assembly: CLSCompliant(false)]
 [assembly: AssemblyVersion("1.2.0.0")]
 [assembly: AssemblyFileVersion("1.2.0.0")]
-[assembly: AssemblyInformationalVersion("1.2.0-alpha8")]
+[assembly: AssemblyInformationalVersion("1.2.0")]

--- a/Source/SitecoreSidekick/Handlers/SCSHandler.cs
+++ b/Source/SitecoreSidekick/Handlers/SCSHandler.cs
@@ -112,13 +112,21 @@ namespace SitecoreSidekick.Handlers
 				string payload = sr.ReadToEnd();
 				dynamic ret = null;
 				if (payload.StartsWith("{") || payload == "")
+				{
 					ret = JsonNetWrapper.DeserializeObject<ExpandoObject>(payload);
+				}
+
 				if (ret == null)
+				{
 					ret = new ExpandoObject();
+				}
+
 				ret.payload = payload;
+
 				return ret;
 			}
 		}
+
 		/// <summary>
 		/// processes http request
 		/// </summary>

--- a/Source/SitecoreSidekick/SitecoreSidekick.csproj
+++ b/Source/SitecoreSidekick/SitecoreSidekick.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\inetpub\wwwroot\Debut\Source\Debut.Web\bin\</OutputPath>
+    <OutputPath>..\..\..\..\bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Source/SitecoreSidekick/SitecoreSidekick.csproj
+++ b/Source/SitecoreSidekick/SitecoreSidekick.csproj
@@ -17,7 +17,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
+    <OutputPath>..\..\..\..\inetpub\wwwroot\Debut\Source\Debut.Web\bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
...and also work around .NET < 4.6.1 not defaulting to use TLS 1.2.

Also rename GetResources to RemoteContentService for clarity, fixed logging of remote YAML errors

NOTE: pulled a couple commits from you here too; looks like the output directory might have got messed up too in the csprojs?