### PR TITLE
Fixed the logic to check for SideKickButton in the Core db

### DIFF
--- a/Source/SitecoreSidekick/Pipelines/Initialize/InitializeSidekick.cs
+++ b/Source/SitecoreSidekick/Pipelines/Initialize/InitializeSidekick.cs
@@ -69,7 +69,7 @@ namespace SitecoreSidekick.Pipelines.Initialize
 				return;
 
 			Item sk = core.GetItem(new ID(SidekickButton));
-			if (sk != null)
+			if (sk == null)
 				return;
 			Item right = core.GetItem(new ID(DesktopMenuRight));
 			if (right == null)


### PR DESCRIPTION
Fixed the logic which was preventing the SideKick button being shown in the Desktop menu.
Returning if SitecoreSideKick button is null.