### PR TITLE
use document.innerHTML instead of document.write

### DIFF
--- a/Source/SitecoreSidekick/Resources/scscommand.js
+++ b/Source/SitecoreSidekick/Resources/scscommand.js
@@ -42,4 +42,4 @@ window.onload = function () {
 };
 
 
-document.write("<div id='scs' style='display:none;height:100%;width:100%;position:absolute;z-index:9999;left:0;top:0;'></div>");
+document.innerHTML += "<div id='scs' style='display:none;height:100%;width:100%;position:absolute;z-index:9999;left:0;top:0;'></div>";


### PR DESCRIPTION
use document.innerHTML instead of document.write due to a bug with the sitecore UI

I encountered a problem with the sitecore UI. The Workflow Dropdown got cropped.
![workflow-edit](https://user-images.githubusercontent.com/26430873/30204379-8f899d96-9485-11e7-8b02-351ba28a9002.jpg)
I contacted the sitecore support and they found out that the problem was caused by the document.write() methode.