### PR TITLE
Attempt to fix <root/> entries that specify a database

### DIFF
--- a/ContentMigrator/ContentMigrationController.cs
+++ b/ContentMigrator/ContentMigrationController.cs
@@ -386,7 +386,7 @@ namespace Sidekick.ContentMigrator
 				return null;
 			}
 
-			return data.Id == "" ? ContentMigrationRegistration.Root : new CompareContentTreeNode(_sitecore.GetItemData(data.Id));
+			return data.Id == "" ? ContentMigrationRegistration.Root : new CompareContentTreeNode(_sitecore.GetItemData(data.Id, data.Database));
 		}
 	}
 }

--- a/ContentMigrator/ContentMigrationController.cs
+++ b/ContentMigrator/ContentMigrationController.cs
@@ -84,8 +84,8 @@ namespace Sidekick.ContentMigrator
 			using (new SecurityDisabler())
 			{
 
-				IItemData item = _sitecore.GetItemData(guid);
-				var localRev = _sitecore.GetItemAndChildrenRevision(guid);
+				IItemData item = _sitecore.GetItemData(guid, data.Database);
+				var localRev = _sitecore.GetItemAndChildrenRevision(guid, data.Database);
 				List<Guid> GrandChildren = new List<Guid>();
 				var items = new List<KeyValuePair<Guid, string>>();
 				if (data.Rev == null || !data.Rev.ContainsKey(item.Id) || data.Rev[item.Id] != localRev[item.Id])
@@ -229,8 +229,8 @@ namespace Sidekick.ContentMigrator
 		{
 			using (new SecurityDisabler())
 			{
-				CompareContentTreeNode ret = new CompareContentTreeNode(_sitecore.GetItemData(model.Id), false);
-				ret.BuildDiff(model.Server);
+				CompareContentTreeNode ret = new CompareContentTreeNode(_sitecore.GetItemData(model.Id, model.Database), false);
+				ret.BuildDiff(model.Database, model.Server);
 				return ScsJson(ret);
 			}
 		}

--- a/ContentMigrator/Core/ContentItemInstaller.cs
+++ b/ContentMigrator/Core/ContentItemInstaller.cs
@@ -161,7 +161,7 @@ namespace Sidekick.ContentMigrator.Core
 			try
 			{
 
-				var context = bulkLoader.NewBulkLoadContext("master");
+				var context = bulkLoader.NewBulkLoadContext(args.Database);
 				bulkLoader.LoadItems(context, GetAllItemsToCreate(context, cancellationToken));
 				_checksumManager.RegenerateChecksum();
 			}
@@ -206,7 +206,7 @@ namespace Sidekick.ContentMigrator.Core
 							CurrentlyProcessing.Add(remoteData.Id);
 						}
 
-						IItemData localData = _sitecore.GetItemData(remoteData.Id);
+						IItemData localData = _sitecore.GetItemData(remoteData.Id, args.Database);
 
 						ProcessItem(args, localData, remoteData);
 

--- a/ContentMigrator/Core/ContentMigration.cs
+++ b/ContentMigrator/Core/ContentMigration.cs
@@ -35,15 +35,15 @@ namespace Sidekick.ContentMigrator.Core
 			_model = model;
 			if (model.PullParent)
 			{
-				foreach (var id in model.Ids.Select(Guid.Parse).Where(x => _sitecoreAccess.GetItemData(x) == null))
+				foreach (var id in model.Ids.Select(Guid.Parse).Where(x => _sitecoreAccess.GetItemData(x, model.Database) == null))
 				{
-					var item = _remoteContent.GetRemoteItemData(id, model.Server);
-					var parent = _sitecoreAccess.GetItemData(item.ParentId);
+					var item = _remoteContent.GetRemoteItemData(id, model.Database, model.Server);
+					var parent = _sitecoreAccess.GetItemData(item.ParentId, model.Database);
 					while (parent == null)
 					{
-						item = _remoteContent.GetRemoteItemData(item.ParentId, model.Server);
+						item = _remoteContent.GetRemoteItemData(item.ParentId, model.Database, model.Server);
 						_puller.ItemsToInstall.Add(item);
-						parent = _sitecoreAccess.GetItemData(item.ParentId);
+						parent = _sitecoreAccess.GetItemData(item.ParentId, model.Database);
 					}
 				}
 			}
@@ -53,7 +53,7 @@ namespace Sidekick.ContentMigrator.Core
 				{
 					_installer.SetupTrackerForUnwantedLocalItems(model.Ids.Select(Guid.Parse));
 				}
-				_puller.StartGatheringItems(model.Ids.Select(Guid.Parse), _registration.GetScsRegistration<ContentMigrationRegistration>()?.RemoteThreads ?? 1, model.Children, model.Server, _cancellation.Token, model.IgnoreRevId);
+				_puller.StartGatheringItems(model.Ids.Select(Guid.Parse), model.Database, _registration.GetScsRegistration<ContentMigrationRegistration>()?.RemoteThreads ?? 1, model.Children, model.Server, _cancellation.Token, model.IgnoreRevId);
 				_installer.StartInstallingItems(model, _puller.ItemsToInstall, _registration.GetScsRegistration<ContentMigrationRegistration>()?.WriterThreads ?? 1, _cancellation.Token);
 			});
 		}

--- a/ContentMigrator/Core/Interface/IContentItemPuller.cs
+++ b/ContentMigrator/Core/Interface/IContentItemPuller.cs
@@ -9,7 +9,7 @@ namespace Sidekick.ContentMigrator.Core.Interface
 	public interface IContentItemPuller
 	{
 		bool Completed { get; }
-		void StartGatheringItems(IEnumerable<Guid> rootIds, int threads, bool getChildren, string server, CancellationToken cancellationToken, bool ignoreRevId);
+		void StartGatheringItems(IEnumerable<Guid> rootIds, string database, int threads, bool getChildren, string server, CancellationToken cancellationToken, bool ignoreRevId);
 		BlockingCollection<IItemData> ItemsToInstall { get; }
 	}
 }

--- a/ContentMigrator/Data/CompareContentTreeNode.cs
+++ b/ContentMigrator/Data/CompareContentTreeNode.cs
@@ -70,14 +70,14 @@ namespace Sidekick.ContentMigrator.Data
 			return false;
 		}
 
-		public void BuildDiff(string server)
+		public void BuildDiff(string server, string database)
 		{
 			Compare = new Dictionary<string, List<Tuple<string, string>>>();
 			IItemData itemData = null;
-			itemData = Bootstrap.Container.Resolve<IRemoteContentService>().GetRemoteItemData(Guid.Parse(Id), server);
+			itemData = Bootstrap.Container.Resolve<IRemoteContentService>().GetRemoteItemData(Guid.Parse(Id), database, server);
 			using (new SecurityDisabler())
 			{
-				var localItem = Factory.GetDatabase("master", true).DataManager.DataEngine.GetItem(new ID(Id), LanguageManager.DefaultLanguage, Sitecore.Data.Version.Latest);
+				var localItem = Factory.GetDatabase(database, true).DataManager.DataEngine.GetItem(new ID(Id), LanguageManager.DefaultLanguage, Sitecore.Data.Version.Latest);
 				localItem.Fields.ReadAll();
 				foreach (var chk in itemData.SharedFields)
 				{

--- a/ContentMigrator/Models/DiffRequestModel.cs
+++ b/ContentMigrator/Models/DiffRequestModel.cs
@@ -9,6 +9,7 @@ namespace Sidekick.ContentMigrator.Models
 	public class DiffRequestModel
 	{
 		public string Id;
+		public string Database;
 		public string Server;
 	}
 }

--- a/ContentMigrator/Models/RevisionModel.cs
+++ b/ContentMigrator/Models/RevisionModel.cs
@@ -9,6 +9,7 @@ namespace Sidekick.ContentMigrator.Models
 	public class RevisionModel
 	{
 		public string Id;
+		public string Database;
 		public Dictionary<Guid, string> Rev;
 	}
 }

--- a/ContentMigrator/Resources/cmcontenttreecontroller.js
+++ b/ContentMigrator/Resources/cmcontenttreecontroller.js
@@ -15,7 +15,7 @@
 		vm.buildDiff = function(status, id, events) {
 			if (status !== "cmfieldchanged")
 				return;
-			CMfactory.getDiff(id, vm.server).then(function(response) {
+			CMfactory.getDiff(id, vm.db, vm.server).then(function(response) {
 				events.lastClicked = response.data;
 				events.diff = id;
 				vm.setupCompare(events.lastClicked.Compare, events.showAll, events);
@@ -42,6 +42,7 @@
 		$scope.init = function (nodeId, selectedId, events, server, database) {
 			vm.events = events;
 			vm.data = nodeId;
+			vm.db = database;
 			vm.loading = true;
 			if (typeof(nodeId) === "object")
 				vm.data.loading = true;

--- a/ContentMigrator/Resources/cmfactory.js
+++ b/ContentMigrator/Resources/cmfactory.js
@@ -45,8 +45,8 @@
 			queuedItems: function (operationId) {
 				return $http.post("/scs/cm/cmqueuelength.scsvc", "'" + operationId + "'");
 			},
-			getDiff: function (id, server) {
-				var data = { "id": id, "server": server };
+			getDiff: function (id, database, server) {
+				var data = { "id": id, "server": server, "database": database };
 				return $http.post("/scs/cm/cmbuilddiff.scsvc", data);
 			},
 			getPresets: function (server) {

--- a/ContentMigrator/Resources/cmmastercontroller.js
+++ b/ContentMigrator/Resources/cmmastercontroller.js
@@ -63,7 +63,7 @@
 					vm.events.selected.splice(index, 1);
 					vm.events.selectedIds.splice(index, 1);
 				}
-				ScsFactory.contentTreeSelectedRelated(vm.events.selectedIds, vm.server).then(function (response) {
+				ScsFactory.contentTreeSelectedRelated(vm.events.selectedIds, vm.server, val.DatabaseName).then(function (response) {
 					vm.events.relatedIds = response.data;
 				});
 			}

--- a/ContentMigrator/Services/ContentMigrationManagerService.cs
+++ b/ContentMigrator/Services/ContentMigrationManagerService.cs
@@ -20,7 +20,7 @@ namespace Sidekick.ContentMigrator.Services
 		private readonly Dictionary<string, IContentMigration> _migrations = new Dictionary<string, IContentMigration>();
 		public ContentMigration StartContentMigration(PullItemModel model)
 		{
-			Log.Info($"Starting Content Migration...\n{model.Server}\n{string.Join(", ", model.Ids)}", this);
+			Log.Info($"Starting Content Migration...\n{model.Server}\n{string.Join(", ", model.Ids)}\n{model.Database}", this);
 			string id = Guid.NewGuid().ToString();
 			ContentMigration newMigration = new ContentMigration();
 			newMigration.Status.OperationId = id;

--- a/ContentMigrator/Services/Interface/IRemoteContentService.cs
+++ b/ContentMigrator/Services/Interface/IRemoteContentService.cs
@@ -13,8 +13,8 @@ namespace Sidekick.ContentMigrator.Services.Interface
 {
 	public interface IRemoteContentService
 	{
-		IItemData GetRemoteItemData(Guid id, string server);
-		ChildrenItemDataModel GetRemoteItemDataWithChildren(Guid id, string server, Dictionary<Guid, string> rev = null);
+		IItemData GetRemoteItemData(Guid id, string database, string server);
+		ChildrenItemDataModel GetRemoteItemDataWithChildren(Guid id, string database, string server, Dictionary<Guid, string> rev = null);
 		IItemData DeserializeYaml(string yaml, Guid id);
 		object ChecksumIsGenerating(string server);
 		bool ChecksumRegenerate(string server);

--- a/ContentMigrator/Services/RemoteContentService.cs
+++ b/ContentMigrator/Services/RemoteContentService.cs
@@ -61,7 +61,7 @@ namespace Sidekick.ContentMigrator.Services
 			return _jsonSerializationService.DeserializeObject<bool>(json);
 		}
 
-		public IItemData GetRemoteItemData(Guid id, string server)
+		public IItemData GetRemoteItemData(Guid id, string database, string server)
 		{
 			string url = $"{server}/scs/cm/cmgetitemyaml.scsvc";
 			string parameters = _jsonSerializationService.SerializeObject(id);
@@ -69,10 +69,10 @@ namespace Sidekick.ContentMigrator.Services
 			return DeserializeYaml(yaml, id);
 		}
 
-		public ChildrenItemDataModel GetRemoteItemDataWithChildren(Guid id, string server, Dictionary<Guid, string> rev = null)
+		public ChildrenItemDataModel GetRemoteItemDataWithChildren(Guid id, string database, string server, Dictionary<Guid, string> rev = null)
 		{
 			string url = $"{server}/scs/cm/cmgetitemyamlwithchildren.scsvc";
-			string parameters = _jsonSerializationService.SerializeObject(new {id, rev});
+			string parameters = _jsonSerializationService.SerializeObject(new {id, rev, database});
 			string json = MakeRequest(url, parameters);
 			return _jsonSerializationService.DeserializeObject<ChildrenItemDataModel>(json);
 		}

--- a/ScsContentMigrator.UnitTests/Core/ContentItemPullerTests.cs
+++ b/ScsContentMigrator.UnitTests/Core/ContentItemPullerTests.cs
@@ -25,7 +25,7 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 
 			List<Guid> expectedGuids = new List<Guid> {Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()};
 
-			contentItemPuller.StartGatheringItems(expectedGuids, 0, false, "", CancellationToken.None, false);
+			contentItemPuller.StartGatheringItems(expectedGuids, "master", 0, false, "", CancellationToken.None, false);
 
 			contentItemPuller.ProcessingIds.Count.Should().Be(expectedGuids.Count);
 		}
@@ -34,10 +34,10 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 		public void GatherItems_TakesFromProcessingList()
 		{
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 			
-			contentItemPuller.GatherItems(false, "", CancellationToken.None, false);
+			contentItemPuller.GatherItems(false, "master", "", CancellationToken.None, false);
 
 			contentItemPuller.ProcessingIds.Should().BeEmpty();
 		}
@@ -46,22 +46,22 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 		public void GatherItems_FetchesRemoteContent()
 		{
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 
-			contentItemPuller.GatherItems(false, "", CancellationToken.None, false);
+			contentItemPuller.GatherItems(false, "master", "", CancellationToken.None, false);
 
-			GetSubstitute<IRemoteContentService>().Received(1).GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>());
+			GetSubstitute<IRemoteContentService>().Received(1).GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
 		}
 
 		[Fact]
 		public void GatherItems_DeserializesRemoteContentItem()
 		{
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 
-			contentItemPuller.GatherItems(false, "", CancellationToken.None, false);
+			contentItemPuller.GatherItems(false, "master", "", CancellationToken.None, false);
 
 			GetSubstitute<IYamlSerializationService>().Received(1).DeserializeYaml(Arg.Any<string>(), Arg.Any<string>());
 		}
@@ -72,11 +72,11 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			IItemData expectedItemData = Substitute.For<IItemData>();
 			expectedItemData.Name.Returns("ExpectedName");
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
 			GetSubstitute<IYamlSerializationService>().DeserializeYaml(Arg.Any<string>(), Arg.Any<string>()).Returns(expectedItemData);
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 
-			contentItemPuller.GatherItems(false, "", CancellationToken.None, false);
+			contentItemPuller.GatherItems(false, "master", "", CancellationToken.None, false);
 
 			contentItemPuller.GatheredRemoteItems.Should().NotBeEmpty();
 			contentItemPuller.GatheredRemoteItems.Should().Contain(expectedItemData);
@@ -90,11 +90,11 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			expectedItemData.GetChildren().Returns(new List<IItemData> {Substitute.For<IItemData>()});
 
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
 			GetSubstitute<IYamlSerializationService>().DeserializeYaml(Arg.Any<string>(), Arg.Any<string>()).Returns(expectedItemData);
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 
-			contentItemPuller.GatherItems(false, "", CancellationToken.None, false);
+			contentItemPuller.GatherItems(false, "master", "", CancellationToken.None, false);
 
 			contentItemPuller.GatheredRemoteItems.Count.Should().Be(1);
 		}
@@ -109,12 +109,12 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			expectedItemData.GetChildren().Returns(new List<IItemData> { Substitute.For<IItemData>() });
 
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(parentGuid, Arg.Any<string>()).Returns(new ChildrenItemDataModel {GrandChildren = new List<Guid> {childGuid}});
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(childGuid, Arg.Any<string>()).Returns(new ChildrenItemDataModel());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(parentGuid, Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel {GrandChildren = new List<Guid> {childGuid}});
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(childGuid, Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
 			GetSubstitute<IYamlSerializationService>().DeserializeYaml(Arg.Any<string>(), Arg.Any<string>()).Returns(expectedItemData);
 			contentItemPuller.ProcessingIds.Add(parentGuid);
 
-			contentItemPuller.GatherItems(true, "", CancellationToken.None, false);
+			contentItemPuller.GatherItems(true, "master", "", CancellationToken.None, false);
 
 			contentItemPuller.GatheredRemoteItems.Count.Should().Be(2);
 		}
@@ -123,7 +123,7 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 		public void GatherItems_MultipleItems_CanceledDuringFirstItem_OnlyGathersOneItem()
 		{
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>()).Returns(ci =>
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(ci =>
 			{
 				// Introduce a delay
 				Thread.Sleep(10);
@@ -135,7 +135,7 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 
 			CancellationTokenSource cts = new CancellationTokenSource(10);
-			contentItemPuller.GatherItems(false, "", cts.Token, false);
+			contentItemPuller.GatherItems(false, "master", "", cts.Token, false);
 
 			contentItemPuller.GatheredRemoteItems.Count.Should().BeLessThan(3);
 		}
@@ -148,13 +148,13 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			expectedItemData.GetChildren().Returns(new List<IItemData> { Substitute.For<IItemData>() });
 
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
 			GetSubstitute<IYamlSerializationService>().DeserializeYaml(Arg.Any<string>(), Arg.Any<string>()).Returns(expectedItemData);
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 			contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
 
-			contentItemPuller.GatherItems(false, "", CancellationToken.None, false);
+			contentItemPuller.GatherItems(false, "master", "", CancellationToken.None, false);
 
 			contentItemPuller.GatheredRemoteItems.Count.Should().Be(3);
 		}
@@ -168,7 +168,7 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			expectedItemData.GetChildren().Returns(new List<IItemData> { Substitute.For<IItemData>() });
 
 			ContentItemPuller contentItemPuller = CreateInstance<ContentItemPuller>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemDataWithChildren(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(new ChildrenItemDataModel());
 			GetSubstitute<IYamlSerializationService>().DeserializeYaml(Arg.Any<string>(), Arg.Any<string>()).Returns(expectedItemData);
 			for (int i = 0; i < expectedCount; i++)
 				contentItemPuller.ProcessingIds.Add(Guid.NewGuid());
@@ -179,15 +179,15 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			{
 				Task.Run(() =>
 				{
-					contentItemPuller.GatherItems(false, "", cancellationTokenSource.Token, false);
+					contentItemPuller.GatherItems(false, "master", "", cancellationTokenSource.Token, false);
 				}),
 				Task.Run(() =>
 				{
-					contentItemPuller.GatherItems(false, "", cancellationTokenSource.Token, false);
+					contentItemPuller.GatherItems(false, "master", "", cancellationTokenSource.Token, false);
 				}),
 				Task.Run(() =>
 				{
-					contentItemPuller.GatherItems(false, "", cancellationTokenSource.Token, false);
+					contentItemPuller.GatherItems(false, "master", "", cancellationTokenSource.Token, false);
 				})
 			};
 

--- a/ScsContentMigrator.UnitTests/Core/ContentMigratorTests.cs
+++ b/ScsContentMigrator.UnitTests/Core/ContentMigratorTests.cs
@@ -28,7 +28,7 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			var item = Substitute.For<IItemData>();
 			item.ParentId.Returns(parent);
 			ContentMigration contentMigration = CreateInstance<ContentMigration>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemData(Arg.Any<Guid>(), Arg.Any<string>()).Returns(Substitute.For<IItemData>());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemData(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>()).Returns(Substitute.For<IItemData>());
 			GetSubstitute<IContentItemPuller>().ItemsToInstall.Returns(new BlockingCollection<IItemData>());
 			GetSubstitute<ISitecoreDataAccessService>().GetItemData(parent).Returns(Substitute.For<IItemData>());			
 
@@ -48,9 +48,9 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 			var parentItem = Substitute.For<IItemData>();
 			parentItem.ParentId.Returns(secondParent);
 			ContentMigration contentMigration = CreateInstance<ContentMigration>();
-			GetSubstitute<IRemoteContentService>().GetRemoteItemData(initialTarget, Arg.Any<string>()).Returns(item);
-			GetSubstitute<IRemoteContentService>().GetRemoteItemData(firstParent, Arg.Any<string>()).Returns(parentItem);
-			GetSubstitute<IRemoteContentService>().GetRemoteItemData(secondParent, Arg.Any<string>()).Returns(Substitute.For<IItemData>());
+			GetSubstitute<IRemoteContentService>().GetRemoteItemData(initialTarget, Arg.Any<string>(), Arg.Any<string>()).Returns(item);
+			GetSubstitute<IRemoteContentService>().GetRemoteItemData(firstParent, Arg.Any<string>(), Arg.Any<string>()).Returns(parentItem);
+			GetSubstitute<IRemoteContentService>().GetRemoteItemData(secondParent, Arg.Any<string>(), Arg.Any<string>()).Returns(Substitute.For<IItemData>());
 			GetSubstitute<IContentItemPuller>().ItemsToInstall.Returns(new BlockingCollection<IItemData>());
 			GetSubstitute<ISitecoreDataAccessService>().GetItemData(initialTarget).Returns((IItemData)null);
 			GetSubstitute<ISitecoreDataAccessService>().GetItemData(firstParent).Returns((IItemData)null);
@@ -71,7 +71,7 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 
 			contentMigration.StartContentMigration(new PullItemModel {PullParent = false, Ids = new List<string>{Guid.NewGuid().ToString()}});
 
-			GetSubstitute<IRemoteContentService>().Received(0).GetRemoteItemData(Arg.Any<Guid>(), Arg.Any<string>());
+			GetSubstitute<IRemoteContentService>().Received(0).GetRemoteItemData(Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<string>());
 			GetSubstitute<ISitecoreDataAccessService>().Received(0).GetItemData(Arg.Any<Guid>());
 		}
 
@@ -94,7 +94,7 @@ namespace Sidekick.ContentMigrator.UnitTests.Core
 
 			contentMigration.StartContentMigration(new PullItemModel { PullParent = false, Ids = new List<string> { Guid.NewGuid().ToString() } });
 
-			GetSubstitute<IContentItemPuller>().Received(1).StartGatheringItems(Arg.Any<IEnumerable<Guid>>(), Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<bool>());
+			GetSubstitute<IContentItemPuller>().Received(1).StartGatheringItems(Arg.Any<IEnumerable<Guid>>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<bool>(), Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<bool>());
 		}
 
 		[Fact]

--- a/Source/SitecoreSidekick/Handlers/ScsMainController.cs
+++ b/Source/SitecoreSidekick/Handlers/ScsMainController.cs
@@ -107,7 +107,7 @@ namespace Sidekick.Core.Handlers
 				{
 					var node = _jsonSerializationService.DeserializeObject<Dictionary<string, string>>(
 						await _httpClientService.Post($"{data.Server}/scs/platform/contenttreeselectedrelated.scsvc",
-							$@"{{ ""selectedIds"": {_jsonSerializationService.SerializeObject(data.SelectedIds)}, ""server"": null}}").ConfigureAwait(false));
+							$@"{{ ""selectedIds"": {_jsonSerializationService.SerializeObject(data.SelectedIds)}, ""server"": null, ""database"": ""{data.Database}"" }}").ConfigureAwait(false));
 					return node;
 				}
 			}
@@ -118,16 +118,16 @@ namespace Sidekick.Core.Handlers
 			Dictionary<string, string> ret = new Dictionary<string, string>();
 			foreach (string selectedId in data.SelectedIds)
 			{
-				BuildRelatedTree(ret, selectedId);
+				BuildRelatedTree(ret, selectedId, data.Database);
 			}
 			return ret;
 		}
 
-		private void BuildRelatedTree(Dictionary<string, string> ret, string selectedId)
+		private void BuildRelatedTree(Dictionary<string, string> ret, string selectedId, string database)
 		{
 			using (new SecurityDisabler())
 			{
-				ScsSitecoreItem i = _sitecoreDataAccessService.GetScsSitecoreItem(selectedId).Parent;					
+				ScsSitecoreItem i = _sitecoreDataAccessService.GetScsSitecoreItem(selectedId, database).Parent;					
 				while (i != null)
 				{
 					if (!ret.ContainsKey(i.Id))

--- a/Source/SitecoreSidekick/Models/ContentSelectedRelatedModel.cs
+++ b/Source/SitecoreSidekick/Models/ContentSelectedRelatedModel.cs
@@ -9,6 +9,7 @@ namespace Sidekick.Core.Models
 	public class ContentSelectedRelatedModel
 	{
 		public string Server { get; set; }
+		public string Database { get; set; }
 		public List<string> SelectedIds { get; set; }
 	}
 }

--- a/Source/SitecoreSidekick/Resources/scsfactory.js
+++ b/Source/SitecoreSidekick/Resources/scsfactory.js
@@ -13,8 +13,8 @@
 				var data = { "id": id, "database": database, "server": server };
 				return $http.post("/scs/platform/contenttree.scsvc", data);
 			},
-			contentTreeSelectedRelated: function(selectedIds, server) {
-				var data = { "selectedIds": selectedIds, "server": server };
+			contentTreeSelectedRelated: function(selectedIds, server, database) {
+				var data = { "selectedIds": selectedIds, "server": server, "database": database };
 				return $http.post("/scs/platform/contenttreeselectedrelated.scsvc", data);
 			},
 			valid: function() {

--- a/Source/SitecoreSidekick/Services/Interface/ISitecoreDataAccessService.cs
+++ b/Source/SitecoreSidekick/Services/Interface/ISitecoreDataAccessService.cs
@@ -13,6 +13,7 @@ namespace Sidekick.Core.Services.Interface
 	public interface ISitecoreDataAccessService
 	{
 		ScsSitecoreItem GetScsSitecoreItem(string id);
+		ScsSitecoreItem GetScsSitecoreItem(string id, string database);
 		IItemData GetLatestItemData(string idataId, string database = null);
 		IItemData GetLatestItemData(Guid idataId, string database = null);
 		IItemData GetItemData(string idataId, string database = null);

--- a/Source/SitecoreSidekick/Services/SitecoreDataAccessService.cs
+++ b/Source/SitecoreSidekick/Services/SitecoreDataAccessService.cs
@@ -22,6 +22,15 @@ namespace Sidekick.Core.Services
 	{
 		private readonly Database _db = Factory.GetDatabase("master", false);
 
+		public ScsSitecoreItem GetScsSitecoreItem(string id, string database)
+		{
+			var db = string.IsNullOrWhiteSpace(database) ? _db : Factory.GetDatabase(database,false);
+
+			Item item = db.GetItem(id);
+
+			return new ScsSitecoreItem(item);
+		}
+
 		public ScsSitecoreItem GetScsSitecoreItem(string id)
 		{
 			Item item = _db.GetItem(id);
@@ -92,7 +101,7 @@ namespace Sidekick.Core.Services
 
 		public IEnumerable<string> GetVersions(IItemData itemData)
 		{
-			Item item = GetItem(itemData.Id);
+			Item item = GetItem(itemData.Id, itemData.DatabaseName);
 			return item.Versions.GetVersions(true).Select(v => v[FieldIDs.Revision]);
 		}
 

--- a/Source/SitecoreSidekick/Services/SitecoreDataAccessService.cs
+++ b/Source/SitecoreSidekick/Services/SitecoreDataAccessService.cs
@@ -164,7 +164,7 @@ namespace Sidekick.Core.Services
 		}
 		private string GetItemRevision(Item item)
 		{
-			var ret = item.Languages.Aggregate(new StringBuilder(), (sb, lang) => sb.Append(GetItem(item.ID.Guid, null, lang, Version.Latest).Versions.GetVersions().Aggregate(new StringBuilder(), (sb2, version) => sb2.Append(version[FieldIDs.Revision])).ToString())).ToString().GetHashCode().ToString();
+			var ret = item.Languages.Aggregate(new StringBuilder(), (sb, lang) => sb.Append(GetItem(item.ID.Guid, item.Database.Name, lang, Version.Latest).Versions.GetVersions().Aggregate(new StringBuilder(), (sb2, version) => sb2.Append(version[FieldIDs.Revision])).ToString())).ToString().GetHashCode().ToString();
 
 			return ret;
 		}


### PR DESCRIPTION
A first pass at a fix for the issue raised in #97, addressing the ContentMigrator module and a few core bits.

I've tried to rework a collection of API calls and method signatures so that databases are passed about correctly. Which should allow syncing the core database to work. There are probably better (neater) fixes to some of these issues, but the changes in this PR has been done quickly to enable a colleague to get on with some work, rather than be the ideal fix.

It's not exhaustively tested. I've done testing against a "localhost" root - which will successfully expand a core db tree, and preview/sync. (Obvs with no actual changes...) And my colleague who raised the original issue with me has also tested it between separate instances of his solution, and says that appears to be working similarly.

I wasn't able to make the unit tests run correctly in the v1.7 codebase (I get ~50 failed tests with the unchanged code) so I've not put effort into ensuring the tests aren't affected by these changes. The tests compile - but I didn't have time to work out if these failures were because the tests are broken, or because I was doing this in Sitecore v10 and VS2022.

Shout if you need any other work/changes to get this merged.